### PR TITLE
add minimum exponent to _safe_exp

### DIFF
--- a/choix/opt.py
+++ b/choix/opt.py
@@ -6,9 +6,10 @@ from scipy.special import logsumexp
 
 from .utils import softmax
 
+MAXEXP = 500
 
 def _safe_exp(x):
-    x = min(x, 500)
+    x = max(min(x, MAXEXP), -MAXEXP)
     return math.exp(x)
 
 


### PR DESCRIPTION
Fixes: https://github.com/lucasmaystre/choix/issues/25

Alternative would be to disallow z reaching zero. Like this:

```python
    def hessian(self, params):
        hess = 2 * self._penalty * np.identity(len(params))
        for win, los in self._data:
            z = _safe_exp(params[win] - params[los]) or math.exp(-500) # this changed
            val =  1 / (1/z + 2 + z)
            hess[(win,los),(los,win)] += -val
            hess[(win,los),(win,los)] += +val
        return hess
```

Let me know what you think.